### PR TITLE
feat: detach from husky

### DIFF
--- a/src/checkGitRepo.js
+++ b/src/checkGitRepo.js
@@ -1,0 +1,8 @@
+const { spawnSync } = require('child_process')
+
+const checkGitRepo = () => {
+  if (spawnSync('git', ['rev-parse']).status !== 0) return false
+  return true
+}
+
+module.exports = checkGitRepo

--- a/src/config/prepare-commit-msg.js
+++ b/src/config/prepare-commit-msg.js
@@ -1,4 +1,2 @@
 module.exports = (pkg) => `#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 ${pkg} devmoji -e --lint`

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const chalk = require('chalk')
 const installHooks = require('./installHooks')
 const checkValidProject = require('./checkValidProject')
 const checkPackagerUsed = require('./checkPackagerUsed')
+const checkGitRepo = require('./checkGitRepo')
 
 const [, , ...arguments] = process.argv
 const validArguments = []
@@ -18,6 +19,14 @@ if (arguments.length > 0 && checkValid.has(false)) {
 
 if (!checkValidProject()) {
   console.error(chalk.redBright('\n ❌ No package.json found in project root folder.'))
+  process.exit(1)
+}
+
+if (!checkGitRepo()) {
+  console.error(
+    chalk.redBright(
+      '\n ❌ No Git repository found in current folder. Run `git init` before installing hooks.'
+    ))
   process.exit(1)
 }
 
@@ -49,4 +58,5 @@ if (questions.length > 0) {
     .prompt(questions)
     .then((answers) => installHooks(answers, packager))
 }
-return installHooks({}, packager, arguments)
+
+installHooks({}, packager, arguments)

--- a/src/installHooks.js
+++ b/src/installHooks.js
@@ -1,38 +1,36 @@
 const path = require('path')
 const fs = require('fs')
-const { execSync } = require('child_process')
+const { spawnSync } = require('child_process')
 const { cyan } = require('chalk')
 
 const cz = require('./config/cz')
 const devmoji = require('./config/devmoji')
-const common = require('./config/common')
 const prepareCommitMessage = require('./config/prepare-commit-msg')
 
 const installHooks = (answers, packager) => {
   const pkg = (answers.packager || packager).toLowerCase()
+  const cmd = process.platform === 'win32' ? '.cmd' : ''
   const installCommand = pkg === 'yarn' ? 'add' : 'install'
 
   /* config files */
   const czConfigPath = path.resolve(process.cwd(), '.cz.config.js')
   const devmojiConfigPath = path.resolve(process.cwd(), 'devmoji.config.js')
   /* hook files */
-  const commonPath = path.resolve(process.cwd(), '.husky', 'common.sh')
-  const commitMsgHookPath = path.resolve(process.cwd(), '.husky', 'prepare-commit-msg')
+  const commitMsgHookPath = path.resolve(process.cwd(), '.git', 'hooks', 'prepare-commit-msg')
 
   try {
-    execSync(`${pkg} ${installCommand} -D devmoji husky`)
+    process.stdout.write('Installing Devmoji...')
+    const { status, stderr } = spawnSync(`${pkg}${cmd}`, [installCommand, '-D', 'devmoji'], { encoding: 'utf-8' })
+    if (status !== 0) throw Error(stderr)
+    process.stdout.clearLine()
+    process.stdout.write('Devmoji installed successfully.')
 
-    /* create husky folder if not already presents */
-    if (!fs.readdirSync(process.cwd()).includes('.husky')) {
-      fs.mkdirSync(path.resolve(process.cwd(), '.husky'))
-    }
-
+    process.stdout.write('Copying configuration files...')
     fs.writeFileSync(commitMsgHookPath, prepareCommitMessage(pkg === 'npm' ? 'npx' : pkg))
-    fs.writeFileSync(commonPath, common)
     fs.writeFileSync(czConfigPath, cz)
     fs.writeFileSync(devmojiConfigPath, devmoji)
+    process.stdout.clearLine()
 
-    execSync(`${pkg === 'npm' ? 'npx' : pkg} husky install`)
     console.log(cyan(`\n ✨ Commit hooks installed successfully!`))
   } catch (error) {
     console.error(error)


### PR DESCRIPTION
### Why ditch

Husky is a good package, serves its purpose while being small-sized and very well written, but at this point it's no longer necessary for **commit-hooks** to exist. Detaching from husky will leave commit-hooks with only one dependency, two if later I decide to include **commitizen**.

Hopefully I'm not missing anything, it seems to be all that's remaining between commit-hooks and husky. 

Also added a repository check before installation, like husky does (did, rip ⚰).

